### PR TITLE
Arreglando la eliminación de prendas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'webpacker', '~> 4.2'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
     public_suffix (4.0.4)
     puma (3.12.4)
     rack (2.2.2)
+    rack-proxy (0.6.5)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.7)
@@ -155,6 +157,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webpacker (4.2.2)
+      activesupport (>= 4.2)
+      rack-proxy (>= 0.6.1)
+      railties (>= 4.2)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -179,6 +185,7 @@ DEPENDENCIES
   sqlite3
   tzinfo-data
   web-console (>= 3.3.0)
+  webpacker (~> 4.2)
 
 BUNDLED WITH
    2.0.2

--- a/app/controllers/prendas_controller.rb
+++ b/app/controllers/prendas_controller.rb
@@ -40,6 +40,7 @@ class PrendasController < ApplicationController
 
   def destroy
     Prenda.destroy(params[:id])
+    redirect_to action: :index
   end
 
   private

--- a/app/views/prendas/_prenda.html.erb
+++ b/app/views/prendas/_prenda.html.erb
@@ -9,7 +9,7 @@
       
       <%= link_to "Edit", action: :edit, id: prenda.id %>
       <%= link_to "Show", action: :show, id: prenda.id %>
-      <%= link_to "Destroy", action: :destroy, id: prenda.id %>
+      <%= link_to "Destroy", prenda, method: :delete %>
       <%
 =begin%>
  <button class="actions__like">editar &nbsp; <i class="fas fa-heart"></i> </button>


### PR DESCRIPTION
## :ballot_box_with_check: Cambios

1. :package:  Faltaba la dependencia de `webpacker`, así que la agregué
2. :heavy_multiplication_x:   Se estaba utilizando `action` en lugar de `method` en el botón de delete
3. :leftwards_arrow_with_hook:  Faltaba un redirect a `index` tras eliminar, lo que hacía que no se redibuje la pantalla después de la eliminación y generaba la falsa sensación de que no se estaba eliminando la prenda. 